### PR TITLE
MET-4106 Update log4j version 2.17.1 that fix CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
         <version.slf4j>1.7.30</version.slf4j>
         <version.jul.to.slf4j>1.7.30</version.jul.to.slf4j>
-        <version.log4j>2.17.0</version.log4j>
+        <version.log4j>2.17.1</version.log4j>
 
         <version.spring>5.3.7</version.spring>
         <version.jackson>2.12.3</version.jackson>


### PR DESCRIPTION
Update log4j version from 2.17.0 to 2.17.1 to fix CVE-2021-44832